### PR TITLE
#3268 add error handling for empty kultura session token

### DIFF
--- a/src/rfa/kaltura2/browser/static/js/kalturaFileUploader.js
+++ b/src/rfa/kaltura2/browser/static/js/kalturaFileUploader.js
@@ -10,8 +10,19 @@ function appendStyle(url) {
 
 async function getKsToken() {
     const responce = await fetch('./getKs');
-    const data = await responce.json();
-    KALTURA_SESSION_TOKEN = data.ks;
+    try {
+        const data = await responce.json();
+        KALTURA_SESSION_TOKEN = data.ks;
+        if(!data.ks || !data.ks.length) throw new Error("Kultura Session Token is empty")
+    } catch(e) {
+        console.error(e);
+        $('#fileuploadBtn').attr('disabled', 'disabled');
+        $('#successmsg').removeClass('hidden');
+        $('#successmsg').children()[1].innerHTML = `<strong>There was an internal error </strong>.
+        <br/>Please take a screenshot and report this incedent to webtech@rfa.org. 
+        <br/> ${e}
+        <br/><strong>To continue reload this page and try again.</strong>`
+    }
 }
 
 appendStyle('++plone++rfa.kaltura2/css/jquery.fileupload-ui.css');

--- a/src/rfa/kaltura2/browser/static/js/kalturaFileUploader.js
+++ b/src/rfa/kaltura2/browser/static/js/kalturaFileUploader.js
@@ -19,7 +19,7 @@ async function getKsToken() {
         $('#fileuploadBtn').attr('disabled', 'disabled');
         $('#successmsg').removeClass('hidden');
         $('#successmsg').children()[1].innerHTML = `<strong>There was an internal error </strong>.
-        <br/>Please take a screenshot and report this incedent to webtech@rfa.org. 
+        <br/>Please take a screenshot and report this incident to your administrator.
         <br/> ${e}
         <br/><strong>To continue reload this page and try again.</strong>`
     }


### PR DESCRIPTION
* show a user friendly error message if the endpoint /getKs responds with an empty value
* disable add video button if the error occurs
* advice users to reload the page